### PR TITLE
Prepare SWEET v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The installer will automatically:
 
 ### Citation in Methods Section
 
-Image segmentation and area calculation were performed using SWEET v1.0 [1], an open-source tool based on the Segment Anything Model (SAM) [2]. The software enables automated batch segmentation through interactive point annotations and calculates the percentage of segmented regions relative to the total image area.
+Image segmentation and area calculation were performed using SWEET v1.1 [1], an open-source tool based on the Segment Anything Model (SAM) [2]. The software enables automated batch segmentation through interactive point annotations and calculates the percentage of segmented regions relative to the total image area.
 
 #### References
 [1] "SWEET: SAM Widget for Edge Evaluation Tool," GitHub repository, 2025. [Online]. Available: https://github.com/baijinming97/SWEET
@@ -307,7 +307,7 @@ SWEET/
 
 ### 方法部分引用
 
-图像分割和面积计算使用SWEET v1.0 [1]完成，该工具基于Segment Anything Model (SAM) [2]。软件通过交互式标注点实现自动批量分割，并计算分割区域占图像总面积的百分比。
+图像分割和面积计算使用SWEET v1.1 [1]完成，该工具基于Segment Anything Model (SAM) [2]。软件通过交互式标注点实现自动批量分割，并计算分割区域占图像总面积的百分比。
 
 #### 参考文献
 [1] "SWEET: SAM Widget for Edge Evaluation Tool," GitHub repository, 2025. [Online]. Available: https://github.com/baijinming97/SWEET
@@ -316,4 +316,4 @@ SWEET/
 
 ---
 
-**SWEET v1.0** - Making AI segmentation accessible to everyone 🎉
+**SWEET v1.1** - Making AI segmentation accessible to everyone 🎉

--- a/SWEET_Windows.bat
+++ b/SWEET_Windows.bat
@@ -11,7 +11,13 @@ echo.
 
 cd /d "%~dp0"
 
-set "VENV_PYTHON=python\Scripts\python.exe"
+set "APP_DIR=%~dp0"
+set "VENV_DIR=%APP_DIR%python"
+set "VENV_PYTHON=%VENV_DIR%\Scripts\python.exe"
+set "QT_ROOT=%VENV_DIR%\Lib\site-packages\PyQt5\Qt5"
+set "QT_PLUGIN_PATH=%QT_ROOT%\plugins"
+set "QT_QPA_PLATFORM_PLUGIN_PATH=%QT_PLUGIN_PATH%\platforms"
+set "PATH=%QT_ROOT%\bin;%PATH%"
 
 if not exist "%VENV_PYTHON%" (
     echo ERROR: Python environment not found!
@@ -21,6 +27,13 @@ if not exist "%VENV_PYTHON%" (
     echo.
     pause
     exit /b 1
+)
+
+if not exist "%QT_QPA_PLATFORM_PLUGIN_PATH%\qwindows.dll" (
+    echo WARNING: Qt Windows platform plugin was not found:
+    echo    %QT_QPA_PLATFORM_PLUGIN_PATH%\qwindows.dll
+    echo SWEET will still attempt to run...
+    echo.
 )
 
 echo Platform: Windows

--- a/src/install.py
+++ b/src/install.py
@@ -650,7 +650,7 @@ class SWEETInstaller:
             "python_version": python_version,
             "torch_type": "GPU (CUDA)" if has_gpu else "CPU",
             "packages_count": packages_count,
-            "installer_version": "1.0"
+            "installer_version": "1.1"
         }
         
         try:

--- a/src/mask_prompt_utils.py
+++ b/src/mask_prompt_utils.py
@@ -1,0 +1,103 @@
+import cv2
+import numpy as np
+
+
+POSITIVE_MASK_BONUS = 0.12
+NEGATIVE_MASK_PENALTY = 0.85
+RANK_RADIUS_RATIO = 0.015
+ERASE_RADIUS_RATIO = 0.025
+MIN_RANK_RADIUS = 6
+MAX_RANK_RADIUS = 40
+MIN_ERASE_RADIUS = 18
+MAX_ERASE_RADIUS = 90
+
+
+def prompt_radius_for_shape(mask_shape, ratio, min_radius, max_radius):
+    h, w = mask_shape[:2]
+    scaled_radius = int(round(min(h, w) * ratio))
+    return max(min_radius, min(max_radius, scaled_radius))
+
+
+def point_disk_coverage(mask, point, radius):
+    mask_bool = np.asarray(mask) > 0
+    h, w = mask_bool.shape[:2]
+    x = int(round(float(point[0])))
+    y = int(round(float(point[1])))
+
+    if x < 0 or x >= w or y < 0 or y >= h:
+        return 0.0
+
+    x0 = max(0, x - radius)
+    x1 = min(w, x + radius + 1)
+    y0 = max(0, y - radius)
+    y1 = min(h, y + radius + 1)
+
+    yy, xx = np.ogrid[y0:y1, x0:x1]
+    disk = (xx - x) ** 2 + (yy - y) ** 2 <= radius ** 2
+    if not np.any(disk):
+        return 0.0
+
+    return float(np.mean(mask_bool[y0:y1, x0:x1][disk]))
+
+
+def rank_prompt_masks(masks, scores, input_points, input_labels):
+    adjusted_scores = np.asarray(scores, dtype=float).copy()
+    if len(adjusted_scores) == 0:
+        return 0, adjusted_scores
+
+    if input_points is None or input_labels is None or len(input_points) == 0:
+        return int(np.argmax(adjusted_scores)), adjusted_scores
+
+    for mask_index, mask in enumerate(masks):
+        radius = prompt_radius_for_shape(
+            mask.shape,
+            RANK_RADIUS_RATIO,
+            MIN_RANK_RADIUS,
+            MAX_RANK_RADIUS,
+        )
+        positive_coverages = []
+        negative_coverages = []
+
+        for point, label in zip(input_points, input_labels):
+            coverage = point_disk_coverage(mask, point, radius)
+            if int(label) == 1:
+                positive_coverages.append(coverage)
+            else:
+                negative_coverages.append(coverage)
+
+        if positive_coverages:
+            adjusted_scores[mask_index] += POSITIVE_MASK_BONUS * np.mean(positive_coverages)
+        if negative_coverages:
+            adjusted_scores[mask_index] -= NEGATIVE_MASK_PENALTY * np.mean(negative_coverages)
+
+    return int(np.argmax(adjusted_scores)), adjusted_scores
+
+
+def apply_negative_point_exclusions(mask, negative_points):
+    if not negative_points:
+        return mask
+
+    source_mask = np.asarray(mask)
+    work_mask = (source_mask > 0).astype(np.uint8)
+    h, w = work_mask.shape[:2]
+    radius = prompt_radius_for_shape(
+        work_mask.shape,
+        ERASE_RADIUS_RATIO,
+        MIN_ERASE_RADIUS,
+        MAX_ERASE_RADIUS,
+    )
+
+    for point in negative_points:
+        x = int(round(float(point[0])))
+        y = int(round(float(point[1])))
+        if 0 <= x < w and 0 <= y < h:
+            cv2.circle(work_mask, (x, y), radius, 0, -1)
+
+    if source_mask.dtype == np.bool_:
+        return work_mask.astype(bool)
+
+    max_value = np.max(source_mask) if source_mask.size else 0
+    if max_value <= 1:
+        return work_mask.astype(source_mask.dtype)
+
+    return (work_mask * max_value).astype(source_mask.dtype)

--- a/src/qt_bootstrap.py
+++ b/src/qt_bootstrap.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+
+_dll_directory_handles = []
+
+
+def configure_qt_plugins():
+    """Point PyQt5 at the bundled Qt plugins when running from the portable venv."""
+    if not sys.platform.startswith("win"):
+        return
+
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    qt_root = os.path.join(
+        project_root,
+        "python",
+        "Lib",
+        "site-packages",
+        "PyQt5",
+        "Qt5",
+    )
+    plugin_root = os.path.join(qt_root, "plugins")
+    platform_root = os.path.join(plugin_root, "platforms")
+
+    if not os.path.exists(os.path.join(platform_root, "qwindows.dll")):
+        return
+
+    os.environ["QT_PLUGIN_PATH"] = plugin_root
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = platform_root
+
+    qt_bin = os.path.join(qt_root, "bin")
+    path_parts = [os.path.normcase(path) for path in os.environ.get("PATH", "").split(os.pathsep)]
+    if os.path.normcase(qt_bin) not in path_parts:
+        os.environ["PATH"] = qt_bin + os.pathsep + os.environ.get("PATH", "")
+
+    if hasattr(os, "add_dll_directory"):
+        _dll_directory_handles.append(os.add_dll_directory(qt_bin))

--- a/src/sam_annotator_chinese.py
+++ b/src/sam_annotator_chinese.py
@@ -9,6 +9,7 @@ from qt_bootstrap import configure_qt_plugins
 
 configure_qt_plugins()
 
+from mask_prompt_utils import apply_negative_point_exclusions, rank_prompt_masks
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                              QHBoxLayout, QPushButton, QLabel, QFileDialog,
                              QMessageBox, QProgressBar, QProgressDialog, QDialog)
@@ -290,9 +291,21 @@ class SAMModelWrapper:
                 multimask_output=True,
             )
             
-            best_mask_idx = np.argmax(scores)
+            best_mask_idx, adjusted_scores = rank_prompt_masks(
+                masks,
+                scores,
+                input_points,
+                input_labels,
+            )
             best_mask = masks[best_mask_idx]
             best_score = scores[best_mask_idx]
+            if len(negative_points) > 0:
+                logger.debug(
+                    "Mask scores raw=%s adjusted=%s selected=%d",
+                    np.round(scores, 4).tolist(),
+                    np.round(adjusted_scores, 4).tolist(),
+                    best_mask_idx,
+                )
             
             # 应用最大连通组件过滤
             if SAM_AVAILABLE:
@@ -310,7 +323,9 @@ class SAMModelWrapper:
                 resize_time = time.time() - resize_start
                 logger.debug(f"掩码放大耗时: {resize_time:.3f}秒")
                 best_mask = best_mask_resized.astype(bool)
-            
+
+            best_mask = apply_negative_point_exclusions(best_mask, negative_points)
+
             predict_time = time.time() - start_time
             logger.info(f"SAM预测完成，耗时: {predict_time:.3f}秒，置信度: {best_score:.3f}")
             
@@ -630,6 +645,7 @@ class FastImageLabel(QLabel):
         
         self.current_mask = cv2.GaussianBlur(self.current_mask, (11, 11), 0)
         self.current_mask = (self.current_mask > 128).astype(np.uint8) * 255
+        self.current_mask = apply_negative_point_exclusions(self.current_mask, self.negative_points)
         self.show_mask = True
         self.cached_base_pixmap = None
         

--- a/src/sam_annotator_chinese.py
+++ b/src/sam_annotator_chinese.py
@@ -5,8 +5,12 @@ import numpy as np
 import time
 import logging
 from datetime import datetime
-from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, 
-                             QHBoxLayout, QPushButton, QLabel, QFileDialog, 
+from qt_bootstrap import configure_qt_plugins
+
+configure_qt_plugins()
+
+from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
+                             QHBoxLayout, QPushButton, QLabel, QFileDialog,
                              QMessageBox, QProgressBar, QProgressDialog, QDialog)
 from PyQt5.QtCore import Qt, QPoint, pyqtSignal, QTimer, QThread, pyqtSlot
 from PyQt5.QtGui import QPixmap, QPainter, QPen, QColor, QImage, QKeyEvent

--- a/src/sam_annotator_english.py
+++ b/src/sam_annotator_english.py
@@ -5,8 +5,12 @@ import numpy as np
 import time
 import logging
 from datetime import datetime
-from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, 
-                             QHBoxLayout, QPushButton, QLabel, QFileDialog, 
+from qt_bootstrap import configure_qt_plugins
+
+configure_qt_plugins()
+
+from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
+                             QHBoxLayout, QPushButton, QLabel, QFileDialog,
                              QMessageBox, QProgressBar, QProgressDialog, QDialog)
 from PyQt5.QtCore import Qt, QPoint, pyqtSignal, QTimer, QThread, pyqtSlot
 from PyQt5.QtGui import QPixmap, QPainter, QPen, QColor, QImage, QKeyEvent

--- a/src/sam_annotator_english.py
+++ b/src/sam_annotator_english.py
@@ -9,6 +9,7 @@ from qt_bootstrap import configure_qt_plugins
 
 configure_qt_plugins()
 
+from mask_prompt_utils import apply_negative_point_exclusions, rank_prompt_masks
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                              QHBoxLayout, QPushButton, QLabel, QFileDialog,
                              QMessageBox, QProgressBar, QProgressDialog, QDialog)
@@ -290,9 +291,21 @@ class SAMModelWrapper:
                 multimask_output=True,
             )
             
-            best_mask_idx = np.argmax(scores)
+            best_mask_idx, adjusted_scores = rank_prompt_masks(
+                masks,
+                scores,
+                input_points,
+                input_labels,
+            )
             best_mask = masks[best_mask_idx]
             best_score = scores[best_mask_idx]
+            if len(negative_points) > 0:
+                logger.debug(
+                    "Mask scores raw=%s adjusted=%s selected=%d",
+                    np.round(scores, 4).tolist(),
+                    np.round(adjusted_scores, 4).tolist(),
+                    best_mask_idx,
+                )
             
             # Apply largest connected component filtering
             if SAM_AVAILABLE:
@@ -310,7 +323,9 @@ class SAMModelWrapper:
                 resize_time = time.time() - resize_start
                 logger.debug(f"Mask resize time: {resize_time:.3f} seconds")
                 best_mask = best_mask_resized.astype(bool)
-            
+
+            best_mask = apply_negative_point_exclusions(best_mask, negative_points)
+
             predict_time = time.time() - start_time
             logger.info(f"SAM prediction completed, time taken: {predict_time:.3f} seconds, confidence: {best_score:.3f}")
             
@@ -630,6 +645,7 @@ class FastImageLabel(QLabel):
         
         self.current_mask = cv2.GaussianBlur(self.current_mask, (11, 11), 0)
         self.current_mask = (self.current_mask > 128).astype(np.uint8) * 255
+        self.current_mask = apply_negative_point_exclusions(self.current_mask, self.negative_points)
         self.show_mask = True
         self.cached_base_pixmap = None
         


### PR DESCRIPTION
## Summary
- Set bundled PyQt5 Qt plugin paths so Windows can find qwindows.dll after moving or extracting the project.
- Strengthen negative red-point prompts by re-ranking SAM candidate masks against positive and negative point coverage.
- Hard-exclude a small radius around red points from the final mask after SAM prediction.
- Apply the same exclusion to fallback masks and update visible version metadata to v1.1.

## Performance
- No extra SAM inference is added.
- Candidate re-ranking only checks the masks SAM already returned.
- Final red-point exclusion is a small OpenCV mask operation, so the added cost should be negligible compared with SAM.

## Verification
- py_compile passed for mask_prompt_utils.py, qt_bootstrap.py, sam_annotator_english.py, sam_annotator_chinese.py, and install.py.
- Synthetic mask behavior test selects the candidate that avoids the red point and verifies red-point hard exclusion.
- Local installed copy verified QApplication startup after clearing Qt plugin environment variables.