### PR TITLE
SWEET v1.2: cross-platform IO, debris-aware masks, stronger red point…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python virtual environment (created by install.py)
+python/
+
+# Downloaded SAM model weights (fetched by the installer)
+models/
+
+# Logs
+logs/
+*.log
+
+# Byte-compiled / cache
+__pycache__/
+*.pyc
+
+# Installer metadata
+sweet_install.json
+
+# Local benchmark / research data and generated results (do NOT publish)
+data/bench/
+
+# Segmentation outputs written next to source images
+*_segmented.png
+*_comparison.png
+segmentation_results*.csv
+
+# Local dev helpers
+.pypath

--- a/README.md
+++ b/README.md
@@ -30,9 +30,16 @@ Perfect for:
 
 ### Release Notes
 
-**Latest version:** [SWEET v1.1](https://github.com/baijinming97/SWEET/releases/tag/v1.1)
+**Latest version:** SWEET v1.2
 
-**Previous version:** [SWEET v1.0](https://github.com/baijinming97/SWEET/releases/tag/v1.0)
+**Previous versions:** [v1.1](https://github.com/baijinming97/SWEET/releases/tag/v1.1) · [v1.0](https://github.com/baijinming97/SWEET/releases/tag/v1.0)
+
+SWEET v1.2 includes:
+- **Cross-platform robustness:** image read/write now works with non-ASCII paths and spaces in filenames (fixes silent failures on folders such as `D:\...\硕士\...`); robust segmented-output naming (`.tif/.tiff/.TIF`); fixed the macOS launcher (it called a non-existent script); more collision-resistant batch image hashing.
+- **Better masks on hard images:** optional CLAHE contrast normalisation before SAM, keep every wound piece that contains a positive point (not just the largest), and fill small cell debris inside the gap so debris counts as gap.
+- **Stronger, boundary-safe red (negative) points:** a red click removes the wrong region (pinched-off lobe + small adaptive disk) without eating the wound when placed on an edge.
+- **Adaptive model:** auto-uses the higher-quality `vit_l` on NVIDIA GPUs while keeping the fast `vit_b` CPU path; the installer fetches `vit_l` on GPU machines. Fixed a Windows torch/Qt DLL-order startup crash.
+- **Advanced Settings panel** (collapsible) to tune contrast, debris fill, edge smoothing, and red-point strength live.
 
 SWEET v1.1 includes:
 - Windows startup fix for PyQt5/Qt platform plugin detection, including the common `qwindows.dll` startup error after moving or extracting the project folder.
@@ -187,9 +194,16 @@ SWEET 是一个智能工具，帮助您：
 
 ### 版本说明
 
-**最新版:** [SWEET v1.1](https://github.com/baijinming97/SWEET/releases/tag/v1.1)
+**最新版:** SWEET v1.2
 
-**旧版:** [SWEET v1.0](https://github.com/baijinming97/SWEET/releases/tag/v1.0)
+**旧版:** [v1.1](https://github.com/baijinming97/SWEET/releases/tag/v1.1) · [v1.0](https://github.com/baijinming97/SWEET/releases/tag/v1.0)
+
+SWEET v1.2 更新内容:
+- **跨平台健壮性：** 图像读写支持非 ASCII 路径与含空格文件名（修复 `D:\...\硕士\...` 这类目录下静默读不出图的问题）；分割结果文件名更稳健（支持 `.tif/.tiff/.TIF`）；修复 macOS 启动器调用了不存在脚本的 bug；批处理图像哈希更不易碰撞。
+- **难图分割改进：** SAM 前可选 CLAHE 对比增强；保留所有"含正向点"的连通块（不再只留最大块）；填充裂缝内的小细胞碎片，使碎片计入裂缝面积。
+- **更强且边界安全的红色（负向）点：** 红点会删除错误区域（被掐断的瓣块 + 小自适应圆），但放在边界上时不会误删伤口。
+- **自适应模型：** 检测到 NVIDIA GPU 时自动使用更高质量的 `vit_l`，无 GPU 时保持 `vit_b` 快路径；安装器在 GPU 机器上自动下载 `vit_l`。修复 Windows 下 torch/Qt 的 DLL 加载顺序导致的启动崩溃。
+- 新增可折叠的**高级设置**面板，可实时调整对比增强、碎片填充、边缘平滑与红点强度。
 
 SWEET v1.1 更新内容:
 - 修复 Windows 下 PyQt5/Qt 平台插件路径识别问题，包括项目移动或解压到新目录后常见的 `qwindows.dll` 启动报错。

--- a/SWEET_macOS.command
+++ b/SWEET_macOS.command
@@ -58,7 +58,7 @@ case $choice in
     2)
         echo
         echo "🚀 启动中文版SWEET..."
-        python/bin/python src/sam_annotator_debug.py
+        python/bin/python src/sam_annotator_chinese.py
         ;;
     *)
         echo

--- a/src/install.py
+++ b/src/install.py
@@ -577,39 +577,40 @@ class SWEETInstaller:
             print(f"   ❌ Installation error: {e}")
             return False
     
-    def download_sam_model(self):
-        """Download SAM model file if not present"""
+    def download_sam_model(self, has_gpu=False):
+        """Download SAM model file(s) if not present.
+        Always fetch vit_b (the CPU fast path). Also fetch vit_l on NVIDIA-GPU
+        machines so SWEET can auto-use the higher-quality model there."""
         models_dir = self.root_dir / "models"
-        model_path = models_dir / "sam_vit_b_01ec64.pth"
-        
-        # Create models directory if it doesn't exist
         models_dir.mkdir(exist_ok=True)
-        
-        # Check if model already exists
-        if model_path.exists():
-            print("🤖 SAM model already exists")
-            print(f"   📍 Location: {model_path.absolute()}")
-            return True
-        
-        print("🤖 Downloading SAM model...")
-        print("   📝 This is required for the segmentation functionality")
-        
-        model_url = "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth"
-        
-        try:
-            if self.download_file(model_url, model_path, "SAM model (375MB)"):
-                print(f"   ✅ SAM model downloaded successfully")
-                print(f"   📍 Saved to: {model_path.absolute()}")
-                return True
-            else:
-                print("   ❌ Failed to download SAM model")
-                print("   ⚠️  SWEET will run in fallback mode without this model")
-                return False
-                
-        except Exception as e:
-            print(f"   ❌ Error downloading SAM model: {e}")
-            print("   ⚠️  SWEET will run in fallback mode without this model")
-            return False
+
+        downloads = [("sam_vit_b_01ec64.pth",
+                      "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth",
+                      "SAM vit_b (375MB)")]
+        if has_gpu is True:  # CUDA only; select_model_path also gates on torch.cuda
+            downloads.append(("sam_vit_l_0b3195.pth",
+                              "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth",
+                              "SAM vit_l (1.2GB, GPU high-quality)"))
+
+        ok_any = False
+        for fname, url, desc in downloads:
+            model_path = models_dir / fname
+            if model_path.exists():
+                print(f"🤖 {fname} already exists")
+                ok_any = True
+                continue
+            print(f"🤖 Downloading {desc}...")
+            try:
+                if self.download_file(url, model_path, desc):
+                    print(f"   ✅ {fname} -> {model_path.absolute()}")
+                    ok_any = True
+                else:
+                    print(f"   ❌ Failed to download {fname}")
+            except Exception as e:
+                print(f"   ❌ Error downloading {fname}: {e}")
+        if not ok_any:
+            print("   ⚠️  No SAM model available; SWEET will run in fallback mode")
+        return ok_any
 
     def verify_installation(self):
         """Quick verification that installation completed"""
@@ -753,8 +754,8 @@ class SWEETInstaller:
             if not self.install_packages(has_gpu):
                 return False
             
-            # Download SAM model
-            self.download_sam_model()
+            # Download SAM model(s)
+            self.download_sam_model(has_gpu)
             
             # Verify installation
             self.verify_installation()

--- a/src/qt_bootstrap.py
+++ b/src/qt_bootstrap.py
@@ -10,6 +10,14 @@ def configure_qt_plugins():
     if not sys.platform.startswith("win"):
         return
 
+    # Load torch's native DLLs BEFORE we prepend Qt's bin to PATH. Otherwise Qt's
+    # bundled runtime DLLs can shadow torch dependencies and make a later
+    # "import torch" fail with OSError (c10.dll load failure) on some Windows setups.
+    try:
+        import torch  # noqa: F401
+    except Exception:
+        pass
+
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     qt_root = os.path.join(
         project_root,

--- a/src/sam_annotator_chinese.py
+++ b/src/sam_annotator_chinese.py
@@ -10,9 +10,11 @@ from qt_bootstrap import configure_qt_plugins
 configure_qt_plugins()
 
 from mask_prompt_utils import apply_negative_point_exclusions, rank_prompt_masks
+import sam_core
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                              QHBoxLayout, QPushButton, QLabel, QFileDialog,
-                             QMessageBox, QProgressBar, QProgressDialog, QDialog)
+                             QMessageBox, QProgressBar, QProgressDialog, QDialog,
+                             QCheckBox, QComboBox)
 from PyQt5.QtCore import Qt, QPoint, pyqtSignal, QTimer, QThread, pyqtSlot
 from PyQt5.QtGui import QPixmap, QPainter, QPen, QColor, QImage, QKeyEvent
 import cv2
@@ -120,11 +122,12 @@ class BatchSegmentationDialog(QDialog):
         else:
             self.time_label.setText("估计剩余时间: 计算中...")
 
-# Import SAM dependencies from utils
+# Import SAM dependencies (segment_anything directly + shared helpers; avoids heavy utils.py deps)
 try:
     logger.info("开始加载SAM依赖...")
     start_time = time.time()
-    from utils import sam_model_registry, SamPredictor, largest_component, label_to_color_image
+    from segment_anything import sam_model_registry, SamPredictor
+    from sam_core import largest_component, label_to_color_image
     import torch
     SAM_AVAILABLE = True
     logger.info(f"SAM依赖加载成功，耗时: {time.time() - start_time:.2f}秒")
@@ -191,11 +194,7 @@ class SAMModelWrapper:
                 # 使用图像的形状和四个角的像素值创建快速哈希
                 quick_hash = (
                     image.shape,
-                    tuple(image[0, 0]),  # 左上角
-                    tuple(image[0, -1]),  # 右上角
-                    tuple(image[-1, 0]),  # 左下角
-                    tuple(image[-1, -1]),  # 右下角
-                    image[image.shape[0]//2, image.shape[1]//2].tobytes()  # 中心点
+                    cv2.resize(image, (16, 16), interpolation=cv2.INTER_AREA).tobytes(),  # 全局缩略图哈希（避免只取角点导致碰撞）
                 )
                 image_hash = hash(quick_hash)
                 hash_time = time.time() - hash_start
@@ -216,7 +215,11 @@ class SAMModelWrapper:
                     if len(image.shape) != 3 or image.shape[2] != 3:
                         logger.error(f"无效的图像形状: {image.shape}, 期望 (H, W, 3)")
                         return False
-                    
+
+                    # SWEET+: SAM 前做 CLAHE 局部对比增强（改善低对比图像）
+                    if getattr(self, 'use_clahe', True):
+                        image = sam_core.clahe_rgb(image)
+
                     # 根据精确模式决定是否缩放
                     if self.precise_mode or self.max_dimension is None:
                         # 精确模式：使用原图
@@ -307,24 +310,27 @@ class SAMModelWrapper:
                     best_mask_idx,
                 )
             
-            # 应用最大连通组件过滤
+            # 如果图像被缩放了，先将mask放大回原始尺寸（仅在压缩模式下）
+            if hasattr(self, 'scale_factor') and self.scale_factor != 1.0 and not self.precise_mode and hasattr(self, 'original_size'):
+                h, w = self.original_size
+                best_mask = cv2.resize(best_mask.astype(np.uint8), (w, h),
+                                       interpolation=cv2.INTER_NEAREST).astype(bool)
+
+            # SWEET+: 保留所有含正点的连通块 + 边界安全的红点 + 轻量清理
+            # （替代"只留最大块 + 小圆洞负点"）。在原始分辨率上处理。
             if SAM_AVAILABLE:
                 try:
-                    best_mask = largest_component(best_mask).astype(bool)
+                    _opts = getattr(self, 'seg_opts', {})
+                    best_mask = sam_core.finalize_mask(
+                        (best_mask.astype(np.uint8) * 255),
+                        positive_points, negative_points,
+                        fill_debris=_opts.get('fill_debris', True),
+                        close_k=_opts.get('close_k', 15),
+                        neg_ratio=_opts.get('neg_ratio', 0.02)) > 0
                 except Exception as e:
-                    logger.warning(f"最大连通组件处理失败: {e}")
-            
-            # 如果图像被缩放了，需要将mask放大回原始尺寸（仅在压缩模式下）
-            if hasattr(self, 'scale_factor') and self.scale_factor != 1.0 and not self.precise_mode and hasattr(self, 'original_size'):
-                resize_start = time.time()
-                h, w = self.original_size
-                best_mask_resized = cv2.resize(best_mask.astype(np.uint8), (w, h), 
-                                              interpolation=cv2.INTER_NEAREST)
-                resize_time = time.time() - resize_start
-                logger.debug(f"掩码放大耗时: {resize_time:.3f}秒")
-                best_mask = best_mask_resized.astype(bool)
-
-            best_mask = apply_negative_point_exclusions(best_mask, negative_points)
+                    logger.warning(f"finalize_mask 失败，回退: {e}")
+                    best_mask = largest_component(best_mask).astype(bool)
+                    best_mask = apply_negative_point_exclusions(best_mask, negative_points)
 
             predict_time = time.time() - start_time
             logger.info(f"SAM预测完成，耗时: {predict_time:.3f}秒，置信度: {best_score:.3f}")
@@ -387,7 +393,7 @@ class FastImageLabel(QLabel):
         # 加载图像
         try:
             load_start = time.time()
-            self.original_image = cv2.imread(image_path, cv2.IMREAD_COLOR)
+            self.original_image = sam_core.imread_unicode(image_path, cv2.IMREAD_COLOR)
             if self.original_image is None:
                 logger.error(f"无法读取图像: {image_path}")
                 return False
@@ -840,7 +846,56 @@ class WoundAnnotatorUI(QMainWindow):
             font-size: 16px; padding: 15px;
         """)
         right_panel.addWidget(self.batch_segment_button)
-        
+
+        # ----- 高级设置（可折叠）-----
+        self.adv_toggle = QPushButton("⚙️ 高级设置 ▸")
+        self.adv_toggle.setStyleSheet(button_style + "background-color: #34495e; border-color: #2c3e50;")
+        self.adv_toggle.clicked.connect(self.toggle_advanced)
+        right_panel.addWidget(self.adv_toggle)
+
+        self.adv_panel = QWidget()
+        self.adv_panel.setStyleSheet("background-color:#ecf0f1; border:1px solid #bdc3c7; border-radius:6px;")
+        adv_layout = QVBoxLayout(self.adv_panel)
+        adv_layout.setContentsMargins(10, 8, 10, 8)
+        adv_layout.setSpacing(6)
+        _lbl_css = "color:#2c3e50; font-size:12px; font-weight:bold; border:none;"
+        _ctl_css = "color:#2c3e50; font-size:12px; border:none;"
+
+        self.cb_clahe = QCheckBox("对比增强 (CLAHE)")
+        self.cb_clahe.setChecked(True)
+        self.cb_clahe.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cb_clahe)
+
+        self.cb_fill = QCheckBox("填充裂缝内碎片")
+        self.cb_fill.setChecked(True)
+        self.cb_fill.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cb_fill)
+
+        _l1 = QLabel("边缘 / 碎片平滑")
+        _l1.setStyleSheet(_lbl_css)
+        adv_layout.addWidget(_l1)
+        self.cmb_smooth = QComboBox()
+        self.cmb_smooth.addItems(["轻", "标准", "强"])
+        self.cmb_smooth.setCurrentIndex(1)
+        self.cmb_smooth.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cmb_smooth)
+
+        _l2 = QLabel("红点强度")
+        _l2.setStyleSheet(_lbl_css)
+        adv_layout.addWidget(_l2)
+        self.cmb_neg = QComboBox()
+        self.cmb_neg.addItems(["弱", "中", "强"])
+        self.cmb_neg.setCurrentIndex(1)
+        self.cmb_neg.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cmb_neg)
+
+        for _w in (self.cb_clahe, self.cb_fill, self.cmb_smooth, self.cmb_neg):
+            _w.setFocusPolicy(Qt.NoFocus)
+
+        self.adv_panel.setVisible(False)
+        right_panel.addWidget(self.adv_panel)
+        # ----------------------------------
+
         right_panel.addStretch()
         
         # 添加右面板
@@ -900,7 +955,24 @@ class WoundAnnotatorUI(QMainWindow):
                 }
             """)
             # 切换到精确模式
-    
+
+    def toggle_advanced(self):
+        """显示/隐藏可折叠的高级设置面板"""
+        vis = not self.adv_panel.isVisible()
+        self.adv_panel.setVisible(vis)
+        self.adv_toggle.setText("⚙️ 高级设置 ▾" if vis else "⚙️ 高级设置 ▸")
+
+    def get_seg_opts(self):
+        """读取高级设置，供分割管线使用"""
+        close_k = (9, 15, 29)[self.cmb_smooth.currentIndex()]
+        neg_ratio = (0.012, 0.02, 0.035)[self.cmb_neg.currentIndex()]
+        return {
+            'use_clahe': self.cb_clahe.isChecked(),
+            'fill_debris': self.cb_fill.isChecked(),
+            'close_k': close_k,
+            'neg_ratio': neg_ratio,
+        }
+
     def auto_save_current_points(self):
         """自动保存当前图片的标记点（静默保存，无提示）"""
         if not self.current_image_path:
@@ -978,7 +1050,7 @@ class WoundAnnotatorUI(QMainWindow):
         if self.image_annotations:
             # 检查是否已经进行过分割
             has_segmented = any(
-                os.path.exists(img_path.replace('.tif', '_segmented.png'))
+                os.path.exists(sam_core.segmented_path(img_path))
                 for img_path in self.image_annotations.keys()
             )
             
@@ -1129,16 +1201,24 @@ class WoundAnnotatorUI(QMainWindow):
             QApplication.processEvents()
             
             try:
-                self.image_label.sam_predictor = SAMModelWrapper(self.image_label.sam_model_path)
+                model_path, model_type = sam_core.select_model_path("models")
+                self.image_label.sam_predictor = SAMModelWrapper(model_path)
                 # 设置精确模式
                 self.image_label.sam_predictor.precise_mode = self.precise_mode
                 self.image_label.sam_predictor.max_dimension = None if self.precise_mode else 512
-                    
-                logger.info(f"SAM模型加载完成，精确模式: {'ON' if self.precise_mode else 'OFF'}")
+
+                logger.info(f"SAM模型加载完成: {model_type} ({model_path})，精确模式: {'ON' if self.precise_mode else 'OFF'}")
             except Exception as e:
                 QMessageBox.critical(self, "错误", f"SAM模型加载失败: {str(e)}")
                 return
-        
+
+        # 每次运行都应用高级设置（面板实时读取）
+        if self.image_label.sam_predictor is not None:
+            opts = self.get_seg_opts()
+            self.image_label.sam_predictor.use_clahe = opts['use_clahe']
+            self.image_label.sam_predictor.seg_opts = opts
+            logger.info(f"分割参数: {opts}")
+
         # 创建进度对话框
         progress_dialog = BatchSegmentationDialog(self)
         progress_dialog.show()
@@ -1189,7 +1269,7 @@ class WoundAnnotatorUI(QMainWindow):
             logger.info(f"处理图片: {os.path.basename(image_path)}")
             
             # 加载图片
-            image = cv2.imread(image_path)
+            image = sam_core.imread_unicode(image_path)
             if image is None:
                 logger.error(f"无法读取图片: {image_path}")
                 return None
@@ -1247,8 +1327,8 @@ class WoundAnnotatorUI(QMainWindow):
             result[mask_area] = (1 - alpha) * result[mask_area] + alpha * color_mask[mask_area]
             
             # 保存
-            output_path = image_path.replace('.tif', '_segmented.png')
-            cv2.imwrite(output_path, cv2.cvtColor(result, cv2.COLOR_RGB2BGR))
+            output_path = sam_core.segmented_path(image_path)
+            sam_core.imwrite_unicode(output_path, cv2.cvtColor(result, cv2.COLOR_RGB2BGR))
             logger.debug(f"保存分割结果: {output_path}")
             
         except Exception as e:
@@ -1335,7 +1415,7 @@ class WoundAnnotatorUI(QMainWindow):
             
             # 保存对比图
             comparison_bgr = cv2.cvtColor(comparison, cv2.COLOR_RGB2BGR)
-            cv2.imwrite(comparison_path, comparison_bgr)
+            sam_core.imwrite_unicode(comparison_path, comparison_bgr)
             
             # 保存结果数据
             image_name = os.path.basename(self.current_image_path)

--- a/src/sam_annotator_english.py
+++ b/src/sam_annotator_english.py
@@ -10,9 +10,11 @@ from qt_bootstrap import configure_qt_plugins
 configure_qt_plugins()
 
 from mask_prompt_utils import apply_negative_point_exclusions, rank_prompt_masks
+import sam_core
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                              QHBoxLayout, QPushButton, QLabel, QFileDialog,
-                             QMessageBox, QProgressBar, QProgressDialog, QDialog)
+                             QMessageBox, QProgressBar, QProgressDialog, QDialog,
+                             QCheckBox, QComboBox)
 from PyQt5.QtCore import Qt, QPoint, pyqtSignal, QTimer, QThread, pyqtSlot
 from PyQt5.QtGui import QPixmap, QPainter, QPen, QColor, QImage, QKeyEvent
 import cv2
@@ -120,11 +122,12 @@ class BatchSegmentationDialog(QDialog):
         else:
             self.time_label.setText("Estimated remaining time: Calculating...")
 
-# Import SAM dependencies from utils
+# Import SAM dependencies (segment_anything directly + shared helpers; avoids heavy utils.py deps)
 try:
     logger.info("Starting to load SAM dependencies...")
     start_time = time.time()
-    from utils import sam_model_registry, SamPredictor, largest_component, label_to_color_image
+    from segment_anything import sam_model_registry, SamPredictor
+    from sam_core import largest_component, label_to_color_image
     import torch
     SAM_AVAILABLE = True
     logger.info(f"SAM dependencies loaded successfully, time taken: {time.time() - start_time:.2f} seconds")
@@ -191,11 +194,7 @@ class SAMModelWrapper:
                 # Create fast hash using image shape and pixel values from four corners
                 quick_hash = (
                     image.shape,
-                    tuple(image[0, 0]),  # Top-left corner
-                    tuple(image[0, -1]),  # Top-right corner
-                    tuple(image[-1, 0]),  # Bottom-left corner
-                    tuple(image[-1, -1]),  # Bottom-right corner
-                    image[image.shape[0]//2, image.shape[1]//2].tobytes()  # Center point
+                    cv2.resize(image, (16, 16), interpolation=cv2.INTER_AREA).tobytes(),  # global thumbnail (collision-safe vs corner-only hash)
                 )
                 image_hash = hash(quick_hash)
                 hash_time = time.time() - hash_start
@@ -216,7 +215,11 @@ class SAMModelWrapper:
                     if len(image.shape) != 3 or image.shape[2] != 3:
                         logger.error(f"Invalid image shape: {image.shape}, expected (H, W, 3)")
                         return False
-                    
+
+                    # SWEET+: CLAHE local-contrast normalisation before SAM (helps low-contrast images)
+                    if getattr(self, 'use_clahe', True):
+                        image = sam_core.clahe_rgb(image)
+
                     # Decide scaling based on precise mode
                     if self.precise_mode or self.max_dimension is None:
                         # Precise mode: use original image
@@ -307,24 +310,27 @@ class SAMModelWrapper:
                     best_mask_idx,
                 )
             
-            # Apply largest connected component filtering
+            # If image was scaled, resize mask back to original size FIRST (only compressed mode)
+            if hasattr(self, 'scale_factor') and self.scale_factor != 1.0 and not self.precise_mode and hasattr(self, 'original_size'):
+                h, w = self.original_size
+                best_mask = cv2.resize(best_mask.astype(np.uint8), (w, h),
+                                       interpolation=cv2.INTER_NEAREST).astype(bool)
+
+            # SWEET+: keep every wound piece touching a green point + boundary-safe red points + gentle cleanup
+            # (replaces largest-component-only + small-disk negative). Runs at original resolution.
             if SAM_AVAILABLE:
                 try:
-                    best_mask = largest_component(best_mask).astype(bool)
+                    _opts = getattr(self, 'seg_opts', {})
+                    best_mask = sam_core.finalize_mask(
+                        (best_mask.astype(np.uint8) * 255),
+                        positive_points, negative_points,
+                        fill_debris=_opts.get('fill_debris', True),
+                        close_k=_opts.get('close_k', 15),
+                        neg_ratio=_opts.get('neg_ratio', 0.02)) > 0
                 except Exception as e:
-                    logger.warning(f"Largest connected component processing failed: {e}")
-            
-            # If image was scaled, need to resize mask back to original size (only in compressed mode)
-            if hasattr(self, 'scale_factor') and self.scale_factor != 1.0 and not self.precise_mode and hasattr(self, 'original_size'):
-                resize_start = time.time()
-                h, w = self.original_size
-                best_mask_resized = cv2.resize(best_mask.astype(np.uint8), (w, h), 
-                                              interpolation=cv2.INTER_NEAREST)
-                resize_time = time.time() - resize_start
-                logger.debug(f"Mask resize time: {resize_time:.3f} seconds")
-                best_mask = best_mask_resized.astype(bool)
-
-            best_mask = apply_negative_point_exclusions(best_mask, negative_points)
+                    logger.warning(f"finalize_mask failed, falling back: {e}")
+                    best_mask = largest_component(best_mask).astype(bool)
+                    best_mask = apply_negative_point_exclusions(best_mask, negative_points)
 
             predict_time = time.time() - start_time
             logger.info(f"SAM prediction completed, time taken: {predict_time:.3f} seconds, confidence: {best_score:.3f}")
@@ -387,7 +393,7 @@ class FastImageLabel(QLabel):
         # Load image
         try:
             load_start = time.time()
-            self.original_image = cv2.imread(image_path, cv2.IMREAD_COLOR)
+            self.original_image = sam_core.imread_unicode(image_path, cv2.IMREAD_COLOR)
             if self.original_image is None:
                 logger.error(f"Unable to read image: {image_path}")
                 return False
@@ -840,7 +846,56 @@ class WoundAnnotatorUI(QMainWindow):
             font-size: 16px; padding: 15px;
         """)
         right_panel.addWidget(self.batch_segment_button)
-        
+
+        # ----- Advanced settings (collapsible) -----
+        self.adv_toggle = QPushButton("⚙️ Advanced Settings ▸")
+        self.adv_toggle.setStyleSheet(button_style + "background-color: #34495e; border-color: #2c3e50;")
+        self.adv_toggle.clicked.connect(self.toggle_advanced)
+        right_panel.addWidget(self.adv_toggle)
+
+        self.adv_panel = QWidget()
+        self.adv_panel.setStyleSheet("background-color:#ecf0f1; border:1px solid #bdc3c7; border-radius:6px;")
+        adv_layout = QVBoxLayout(self.adv_panel)
+        adv_layout.setContentsMargins(10, 8, 10, 8)
+        adv_layout.setSpacing(6)
+        _lbl_css = "color:#2c3e50; font-size:12px; font-weight:bold; border:none;"
+        _ctl_css = "color:#2c3e50; font-size:12px; border:none;"
+
+        self.cb_clahe = QCheckBox("Contrast boost (CLAHE)")
+        self.cb_clahe.setChecked(True)
+        self.cb_clahe.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cb_clahe)
+
+        self.cb_fill = QCheckBox("Fill debris inside wound")
+        self.cb_fill.setChecked(True)
+        self.cb_fill.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cb_fill)
+
+        _l1 = QLabel("Edge / debris smoothing")
+        _l1.setStyleSheet(_lbl_css)
+        adv_layout.addWidget(_l1)
+        self.cmb_smooth = QComboBox()
+        self.cmb_smooth.addItems(["Light", "Standard", "Strong"])
+        self.cmb_smooth.setCurrentIndex(1)
+        self.cmb_smooth.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cmb_smooth)
+
+        _l2 = QLabel("Red-point strength")
+        _l2.setStyleSheet(_lbl_css)
+        adv_layout.addWidget(_l2)
+        self.cmb_neg = QComboBox()
+        self.cmb_neg.addItems(["Gentle", "Medium", "Strong"])
+        self.cmb_neg.setCurrentIndex(1)
+        self.cmb_neg.setStyleSheet(_ctl_css)
+        adv_layout.addWidget(self.cmb_neg)
+
+        for _w in (self.cb_clahe, self.cb_fill, self.cmb_smooth, self.cmb_neg):
+            _w.setFocusPolicy(Qt.NoFocus)
+
+        self.adv_panel.setVisible(False)
+        right_panel.addWidget(self.adv_panel)
+        # -------------------------------------------
+
         right_panel.addStretch()
         
         # Add right panel
@@ -900,7 +955,24 @@ class WoundAnnotatorUI(QMainWindow):
                 }
             """)
             # Switched to precise mode
-    
+
+    def toggle_advanced(self):
+        """Show/hide the collapsible Advanced Settings panel"""
+        vis = not self.adv_panel.isVisible()
+        self.adv_panel.setVisible(vis)
+        self.adv_toggle.setText("⚙️ Advanced Settings ▾" if vis else "⚙️ Advanced Settings ▸")
+
+    def get_seg_opts(self):
+        """Read Advanced Settings into the dict consumed by the segmentation pipeline"""
+        close_k = (9, 15, 29)[self.cmb_smooth.currentIndex()]
+        neg_ratio = (0.012, 0.02, 0.035)[self.cmb_neg.currentIndex()]
+        return {
+            'use_clahe': self.cb_clahe.isChecked(),
+            'fill_debris': self.cb_fill.isChecked(),
+            'close_k': close_k,
+            'neg_ratio': neg_ratio,
+        }
+
     def auto_save_current_points(self):
         """Auto-save current image annotation points (silent save, no prompt)"""
         if not self.current_image_path:
@@ -978,7 +1050,7 @@ class WoundAnnotatorUI(QMainWindow):
         if self.image_annotations:
             # Check if any segmentation has been done
             has_segmented = any(
-                os.path.exists(img_path.replace('.tif', '_segmented.png'))
+                os.path.exists(sam_core.segmented_path(img_path))
                 for img_path in self.image_annotations.keys()
             )
             
@@ -1129,16 +1201,24 @@ class WoundAnnotatorUI(QMainWindow):
             QApplication.processEvents()
             
             try:
-                self.image_label.sam_predictor = SAMModelWrapper(self.image_label.sam_model_path)
+                model_path, model_type = sam_core.select_model_path("models")
+                self.image_label.sam_predictor = SAMModelWrapper(model_path)
                 # Set precise mode
                 self.image_label.sam_predictor.precise_mode = self.precise_mode
                 self.image_label.sam_predictor.max_dimension = None if self.precise_mode else 512
-                    
-                logger.info(f"SAM model loaded, precise mode: {'ON' if self.precise_mode else 'OFF'}")
+
+                logger.info(f"SAM model loaded: {model_type} ({model_path}), precise mode: {'ON' if self.precise_mode else 'OFF'}")
             except Exception as e:
                 QMessageBox.critical(self, "Error", f"SAM model loading failed: {str(e)}")
                 return
-        
+
+        # Apply Advanced Settings each run (panel is read live)
+        if self.image_label.sam_predictor is not None:
+            opts = self.get_seg_opts()
+            self.image_label.sam_predictor.use_clahe = opts['use_clahe']
+            self.image_label.sam_predictor.seg_opts = opts
+            logger.info(f"Segmentation options: {opts}")
+
         # Create progress dialog
         progress_dialog = BatchSegmentationDialog(self)
         progress_dialog.show()
@@ -1189,7 +1269,7 @@ class WoundAnnotatorUI(QMainWindow):
             logger.info(f"Processing image: {os.path.basename(image_path)}")
             
             # Load image
-            image = cv2.imread(image_path)
+            image = sam_core.imread_unicode(image_path)
             if image is None:
                 logger.error(f"Unable to read image: {image_path}")
                 return None
@@ -1247,8 +1327,8 @@ class WoundAnnotatorUI(QMainWindow):
             result[mask_area] = (1 - alpha) * result[mask_area] + alpha * color_mask[mask_area]
             
             # Save
-            output_path = image_path.replace('.tif', '_segmented.png')
-            cv2.imwrite(output_path, cv2.cvtColor(result, cv2.COLOR_RGB2BGR))
+            output_path = sam_core.segmented_path(image_path)
+            sam_core.imwrite_unicode(output_path, cv2.cvtColor(result, cv2.COLOR_RGB2BGR))
             logger.debug(f"Save segmentation result: {output_path}")
             
         except Exception as e:
@@ -1335,7 +1415,7 @@ class WoundAnnotatorUI(QMainWindow):
             
             # Save comparison image
             comparison_bgr = cv2.cvtColor(comparison, cv2.COLOR_RGB2BGR)
-            cv2.imwrite(comparison_path, comparison_bgr)
+            sam_core.imwrite_unicode(comparison_path, comparison_bgr)
             
             # Save result data
             image_name = os.path.basename(self.current_image_path)

--- a/src/sam_core.py
+++ b/src/sam_core.py
@@ -1,0 +1,192 @@
+"""
+SWEET shared core: robust IO + segmentation post-processing + model selection.
+
+Centralised here so the English and Chinese GUIs (sam_annotator_*.py) share one
+implementation. All functions are dependency-light (cv2 + numpy); torch is only
+touched lazily inside select_model_path().
+
+Improvements over the original inline logic:
+  - imread/imwrite that work on non-ASCII / spaced paths (the cv2.imread bug)
+  - CLAHE contrast normalisation before SAM (helps low-contrast images)
+  - keep ALL connected components that contain a positive point (not just largest)
+  - boundary-safe STRONG negatives: small adaptive disk + drop pinched-off lobes
+  - robust segmented-output filename (handles .tif/.tiff/.TIF...)
+  - adaptive model selection (vit_l on GPU, vit_b on CPU)
+"""
+import os
+import numpy as np
+import cv2
+
+
+# ---------------- robust image IO (fixes non-ASCII / spaced paths) ----------------
+def imread_unicode(path, flags=cv2.IMREAD_COLOR):
+    """Drop-in for cv2.imread that survives Chinese paths / spaces / OneDrive."""
+    try:
+        data = np.fromfile(path, dtype=np.uint8)
+    except Exception:
+        return None
+    if data.size == 0:
+        return None
+    return cv2.imdecode(data, flags)
+
+
+def imwrite_unicode(path, img):
+    """Drop-in for cv2.imwrite that survives non-ASCII output paths."""
+    ext = os.path.splitext(path)[1] or ".png"
+    ok, buf = cv2.imencode(ext, img)
+    if ok:
+        try:
+            buf.tofile(path)
+        except Exception:
+            return False
+    return ok
+
+
+def segmented_path(image_path, suffix="_segmented", ext=".png"):
+    """Robust replacement for image_path.replace('.tif', '_segmented.png')."""
+    base, _ = os.path.splitext(image_path)
+    return base + suffix + ext
+
+
+# ---------------- preprocessing ----------------
+def clahe_rgb(img_rgb, clip=2.0, grid=8):
+    """Local contrast enhancement on the L channel; safe for grayscale-ish images."""
+    if img_rgb is None or img_rgb.ndim != 3 or img_rgb.shape[2] != 3:
+        return img_rgb
+    lab = cv2.cvtColor(img_rgb, cv2.COLOR_RGB2LAB)
+    l, a, b = cv2.split(lab)
+    l = cv2.createCLAHE(clipLimit=clip, tileGridSize=(grid, grid)).apply(l)
+    return cv2.cvtColor(cv2.merge([l, a, b]), cv2.COLOR_LAB2RGB)
+
+
+# ---------------- mask post-processing ----------------
+def largest_component(mask):
+    m = (mask > 0).astype(np.uint8)
+    n, labels, stats, _ = cv2.connectedComponentsWithStats(m, connectivity=8)
+    if n <= 1:
+        return m * 255
+    largest = 1 + int(np.argmax(stats[1:, cv2.CC_STAT_AREA]))
+    out = np.zeros_like(m)
+    out[labels == largest] = 255
+    return out
+
+
+def label_to_color_image(label_mask):
+    """Color a label mask for overlay display (ported from utils.py so the GUI
+    no longer needs to import the heavy utils module)."""
+    if label_mask.ndim != 2:
+        raise ValueError('label_mask must be 2D array')
+    labels = np.unique(label_mask)
+    np.random.seed(0)
+    hues = np.random.randint(0, 180, size=int(np.max(labels)) + 1)
+    colors = np.zeros((len(hues), 3), dtype=np.uint8)
+    colors[1:, 0] = hues[1:]
+    colors[1:, 1] = 255
+    colors[1:, 2] = 255
+    color_mask = colors[label_mask]
+    return cv2.cvtColor(color_mask, cv2.COLOR_HSV2BGR)
+
+
+def keep_components_with_points(mask, points):
+    """Keep every connected component containing >=1 positive point (fallback: largest)."""
+    m = (mask > 0).astype(np.uint8)
+    n, labels, stats, _ = cv2.connectedComponentsWithStats(m, connectivity=8)
+    if n <= 1:
+        return m * 255
+    keep = set()
+    h, w = labels.shape
+    for x, y in points or []:
+        xi, yi = int(round(x)), int(round(y))
+        if 0 <= xi < w and 0 <= yi < h and labels[yi, xi] > 0:
+            keep.add(int(labels[yi, xi]))
+    if not keep:
+        keep.add(1 + int(np.argmax(stats[1:, cv2.CC_STAT_AREA])))
+    out = np.zeros_like(m)
+    for lab in keep:
+        out[labels == lab] = 255
+    return out
+
+
+def strong_negative(mask, neg_points, pos_points, erase_ratio=0.02):
+    """Boundary-safe strong red point. SAM has already pulled the boundary back
+    (negatives were passed to predict); here we erase only a SMALL adaptive disk
+    and then drop any lobe pinched off that contains no positive point. A click on
+    the wound edge just nudges it; a thin-necked protrusion gets dropped wholesale.
+    Deliberately NOT a big blunt circle (would eat the real wound at a boundary click)."""
+    m = (mask > 0).astype(np.uint8)
+    if not neg_points:
+        return m * 255
+    h, w = m.shape
+    r = int(round(min(h, w) * erase_ratio))
+    if r > 0:
+        r = max(8, min(50, r))
+        for x, y in neg_points:
+            cv2.circle(m, (int(round(x)), int(round(y))), r, 0, -1)
+    return keep_components_with_points(m * 255, pos_points)
+
+
+def fill_holes(mask, max_frac=0.05):
+    """Fill enclosed background holes (e.g. cell debris floating inside the gap) up
+    to max_frac of the mask area. Debris in the wound counts as wound; a large
+    deliberately-excluded interior region (or red-point cut) is left alone."""
+    m = (mask > 0).astype(np.uint8)
+    inv = (m == 0).astype(np.uint8)
+    n, labels, stats, _ = cv2.connectedComponentsWithStats(inv, connectivity=8)
+    if n <= 1:
+        return m * 255
+    border = (set(labels[0, :]) | set(labels[-1, :]) |
+              set(labels[:, 0]) | set(labels[:, -1]))
+    cap = max_frac * max(1, int(m.sum()))
+    out = m.copy()
+    for lab in range(1, n):
+        if lab in border:                       # touches image edge => outside, not a hole
+            continue
+        if stats[lab, cv2.CC_STAT_AREA] <= cap:  # small enclosed debris => fill
+            out[labels == lab] = 1
+    return out * 255
+
+
+def cleanup(mask, k_open=3, k_close=15, fill_debris=True, max_hole_frac=0.05):
+    """Despeckle, bridge small edge notches from debris touching the wound edge,
+    then swallow small debris fully inside the wound. Keeps the macro wound shape."""
+    m = (mask > 0).astype(np.uint8)
+    if k_open:
+        m = cv2.morphologyEx(m, cv2.MORPH_OPEN,
+                             cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k_open, k_open)))
+    if k_close:
+        m = cv2.morphologyEx(m, cv2.MORPH_CLOSE,
+                             cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k_close, k_close)))
+    m = m * 255
+    if fill_debris:
+        m = fill_holes(m, max_hole_frac)
+    return m
+
+
+def finalize_mask(mask, pos_points, neg_points, fill_debris=True, close_k=15,
+                  neg_ratio=0.02, do_cleanup=True):
+    """Full post-processing at ORIGINAL resolution with ORIGINAL-coord points.
+    Parameters are surfaced in the GUI's Advanced Settings panel."""
+    out = keep_components_with_points(mask, pos_points)
+    if neg_points:
+        out = strong_negative(out, neg_points, pos_points, erase_ratio=neg_ratio)
+    if do_cleanup:
+        out = cleanup(out, k_close=close_k, fill_debris=fill_debris)
+    return out
+
+
+# ---------------- model selection ----------------
+def select_model_path(models_dir, prefer_gpu=True):
+    """Pick (path, type). vit_l when a CUDA GPU is present and the file exists,
+    else vit_b. Keeps the CPU fast path on vit_b."""
+    vit_b = os.path.join(models_dir, "sam_vit_b_01ec64.pth")
+    vit_l = os.path.join(models_dir, "sam_vit_l_0b3195.pth")
+    use_gpu = False
+    if prefer_gpu:
+        try:
+            import torch
+            use_gpu = bool(torch.cuda.is_available())
+        except Exception:
+            use_gpu = False
+    if use_gpu and os.path.exists(vit_l):
+        return vit_l, "vit_l"
+    return vit_b, "vit_b"


### PR DESCRIPTION
…s, GPU model auto-select, Advanced Settings

- sam_core.py (new): shared unicode-safe image IO, CLAHE, keep-components-with-positive-point, boundary-safe strong negatives, small-debris hole fill, adaptive vit_l/vit_b model selection
- both GUIs (english/chinese) wired to sam_core; dropped the heavy utils.py import (use segment_anything directly); added a collapsible Advanced Settings panel (contrast, debris fill, edge smoothing, red-point strength)
- qt_bootstrap.py: load torch before prepending Qt bin to PATH (fixes c10.dll startup crash on Windows)
- install.py: also download vit_l on NVIDIA-GPU machines
- SWEET_macOS.command: launch sam_annotator_chinese.py (was a non-existent sam_annotator_debug.py)